### PR TITLE
Add scaffolding for static plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@ This repository is a template for a Packer multi-plugin. It is intended as a sta
 - A post-processor (`post-processor/scaffolding`)
 - Docs (`docs/`)
 
-These files contain boilerplate code that you will need to edit to create your own Packer multi-plugin. 
-A full guide to creating Packer plugins can be found at [Extanding Packer](https://www.packer.io/docs/extending).
+These files contain boilerplate code that you will need to edit to create your own Packer multi-plugin.
+A full guide to creating Packer plugins can be found at [Extending Packer](https://www.packer.io/docs/extending).
 
-In this repository you will also find a pre-defined GitHub Action configuration for the release workflow 
+In this repository you will also find a pre-defined GitHub Action configuration for the release workflow
 (`.goreleaser.yml` and `.github/workflows/release.yml`).
 
-Please see the [GitHub template repository documentation](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template) 
+Please see the [GitHub template repository documentation](https://docs.github.com/en/free-pro-team@latest/github/creating-cloning-and-archiving-repositories/creating-a-repository-from-a-template)
 for how to create a new repository from this template on GitHub.
 
 ## Requirements

--- a/docs/builders/builder-name.mdx
+++ b/docs/builders/builder-name.mdx
@@ -1,0 +1,63 @@
+---
+description: >
+  The scaffolding builder is used to create endless Packer plugins using
+  a consistent plugin structure.
+page_title: Scaffolding - Builders
+sidebar_title: Scaffolding
+---
+
+# Scaffolding
+
+Type: `scaffolding`
+
+<!--
+  Include a short description about the builder. This is a good place
+  to call out what the builder does, and any requirements for the given
+  builder environment. See https://www.packer.io/docs/builders/null
+-->
+
+The scaffolding builder is used to create endless Packer plugins using
+a consistent plugin structure.
+
+
+<!-- Builder Configuration Fields -->
+
+### Required
+
+- `mock` (string) - The name of the mock to use for the Scaffolding API.
+
+
+<!--
+  Optional Configuration Fields
+
+  Configuration options that are not required or have reasonable defaults
+  should be listed under the optionals section. Defaults values should be
+  noted in the description of the field
+-->
+
+### Optional
+
+- `mock_api_url` (string) - The Scaffolding API endpoint to connect to.
+  Defaults to https://example.com
+
+
+
+<!--
+  A basic example on the usage of the builder. Multiple examples
+  can be provided to highlight various build configurations.
+
+-->
+### Example Usage
+
+
+```hcl
+ source "scaffolding" "example" {
+   mock = "bird"
+ }
+
+ build {
+   sources = [source.scaffolding.example"]
+ }
+```
+
+

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,0 +1,38 @@
+---
+description: >
+  The Scaffolding Packer plugin is a basic template for creating a multi-plugin consisting
+  of a builder, provisioner, and post-processor.
+page_time: Scaffolding - Overview
+sidebar_title: Scaffolding
+---
+
+# Scaffolding Plugins
+
+<!--
+  Include a short overview about the plugin.
+-->
+
+The Scaffolding plugin is intended as a starting point for creating Packer plugins, containing:
+
+- [builder](/docs/builder/scaffolding`) - The scaffolding builder is used to create endless Packer
+  plugins using a consistent plugin structure.
+
+- [provisioner](/docs/provisioner/scaffolding`) - The scaffolding provisioner is used to provisioner
+  Packer builds.
+
+- [post-processor](/docs/post-processor/scaffolding`) - The scaffolding post-processor is used to
+  export scaffolding builds.
+
+<!--
+  The overview page is a good place to document shared configuration or special environment configuration
+  settings such as authentication, debugging guides, etc. Essentially any additional text that a user
+  should be aware of to successfully use the plugin.
+
+  Some additional sections include:
+
+  ### Authentication
+
+  ### Environment Variables
+
+-->
+

--- a/docs/post-processors/postprocessor-name.mdx
+++ b/docs/post-processors/postprocessor-name.mdx
@@ -1,0 +1,59 @@
+---
+description: >
+  The scaffolding post-processor is used to export Packer Scaffolding builds.
+page_title: Scaffolding - Post-Processors
+sidebar_title: Scaffolding
+---
+
+# Scaffolding
+
+Type: `scaffolding`
+
+<!--
+  Include a short description about the post-processor. This is a good place
+  to call out what the post-processor does, and any additional text that might
+  be helpful to a user. See https://www.packer.io/docs/provisioners/null
+-->
+
+The scaffolding post-processor is used to export Packer Scaffolding builds.
+
+
+<!-- Post-Processor Configuration Fields -->
+
+### Required
+
+- `mock` (string) - The output path where to save exported build to.
+
+<!--
+  Optional Configuration Fields
+
+  Configuration options that are not required or have reasonable defaults
+  should be listed under the optionals section. Defaults values should be
+  noted in the description of the field
+-->
+
+### Optional
+
+
+<!--
+  A basic example on the usage of the post-processor. Multiple examples
+  can be provided to highlight various configurations.
+
+-->
+### Example Usage
+
+
+```hcl
+ source "scaffolding" "example" {
+   mock = "jay"
+ }
+
+ build {
+   sources = ["source.scaffolding.example"]
+
+   post-processor "scaffolding" {
+     mock = "builds/scaffolding.box"
+   }
+ }
+```
+

--- a/docs/provisioners/provisioner-name.mdx
+++ b/docs/provisioners/provisioner-name.mdx
@@ -1,0 +1,62 @@
+---
+description: >
+  The scaffolding provisioner is used to provisioner Packer builds.
+page_title: Scaffolding - Provisioners
+sidebar_title: Scaffolding
+---
+
+# Scaffolding
+
+Type: `scaffolding`
+
+<!--
+  Include a short description about the provisioner. This is a good place
+  to call out what the provisioner does, and any additional text that might
+  be helpful to a user. See https://www.packer.io/docs/provisioners/null
+-->
+
+The scaffolding provisioner is used to provisioner Packer builds.
+
+
+<!-- Provisioner Configuration Fields -->
+
+### Required
+
+- `mock` (string) - The name of the mock string to display.
+
+
+<!--
+  Optional Configuration Fields
+
+  Configuration options that are not required or have reasonable defaults
+  should be listed under the optionals section. Defaults values should be
+  noted in the description of the field
+-->
+
+### Optional
+
+
+<!--
+  A basic example on the usage of the provisioner. Multiple examples
+  can be provided to highlight various configurations.
+
+-->
+### Example Usage
+
+
+```hcl
+ source "null" "example" {
+   communicator = "none"
+ }
+
+ build {
+   source "null.example" {
+     name = "jay"
+   }
+
+   provisioner "scaffolding" {
+     mock = "mocking ${source.name}"
+   }
+ }
+```
+


### PR DESCRIPTION
This change contains the base directory structure for plugin documentation, along with markdown templates for each of the plugin types.

- [ ] Future PR add logic for validating documentation. 
- [ ] Future PR add instructions, possible hook, for auto generating docs.