### PR TITLE
Remove protocol versioning from checksum name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,7 +60,7 @@ archives:
 - format: zip
   name_template: '{{ .ProjectName }}_v{{ .Version }}_x{{ .Env.API_VERSION }}_{{ .Os }}_{{ .Arch }}'
 checksum:
-  name_template: '{{ .ProjectName }}_v{{ .Version }}_x{{ .Env.API_VERSION }}_SHA256SUMS'
+  name_template: '{{ .ProjectName }}_v{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
   - artifacts: checksum


### PR DESCRIPTION
This will allow to also tell the versions of a release if the major version changes. The checksum file will serve as sort of an index file.