### PR TITLE
Link built binary in plugins path

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ for how to create a new repository from this template on GitHub.
 ## Running Acceptance Tests
 
 Make sure to install the plugin with `go install .` and to have Packer installed locally.
+Then source the built binary to the plugin path with `ln -s $GOPATH/bin/packer-plugin-scaffolding ~/.packer.d/plugins/packer-plugin-scaffolding`
 Once everything needed is set up, run: 
 ```
 PACKER_ACC=1 go test -count 1 -v ./... -timeout=120m

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ for how to create a new repository from this template on GitHub.
 
 ## Running Acceptance Tests
 
-Make sure to install the plugin with `go install .` and to have Packer installed locally.
-Then source the built binary to the plugin path with `ln -s $GOPATH/bin/packer-plugin-scaffolding ~/.packer.d/plugins/packer-plugin-scaffolding`
-Once everything needed is set up, run: 
+Make sure to install the plugin with `go install .` and to have Packer installed locally.  
+Then source the built binary to the plugin path with `ln -s $GOPATH/bin/packer-plugin-scaffolding ~/.packer.d/plugins/packer-plugin-scaffolding`  
+Once everything needed is set up, run:  
 ```
 PACKER_ACC=1 go test -count 1 -v ./... -timeout=120m
 ```


### PR DESCRIPTION
Reading around there seems to be a lot of rapid change about the plugin path so I wanted to add this to ensure it was the intents of this project.

From what I understand of the `go install` command it should put in in `GOPATH` from there the binary is linked to the plugin path that it expects.

With this detail the readme works as expected from `clone`.