### PR TITLE
Update goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -8,13 +8,6 @@ before:
     # Even though, this an optional step.
     - go test ./...
 
-    # You may remove this if you generate these on your own
-    - go install github.com/hashicorp/packer/cmd/mapstructure-to-hcl2
-    - go generate ./...
-
-    # Install packer-plugins-check to check binary compatibility with Packer
-    - go install github.com/hashicorp/packer/cmd/packer-plugins-check
-
 builds:
   # A separated build to run the packer-plugins-check only once for a linux_amd64 binary
   -
@@ -22,8 +15,10 @@ builds:
     mod_timestamp: '{{ .CommitTimestamp }}'
     hooks:
       post:
-        # This will check plugin compatibility by making sure packer can load the binary
-        - cmd: packer-plugins-check -load={{ .Name }}
+        # This will check plugin compatibility against latest version of Packer
+        - cmd: |
+            go install github.com/hashicorp/packer/cmd/packer-plugins-check &&
+            packer-plugins-check -load={{ .Name }}
           dir: "{{ dir .Path}}"
     flags:
       - -trimpath #removes all file system paths from the compiled executable


### PR DESCRIPTION
This moves the packer-plugins-check cmd installation to the folder where the binary to be checked is placed, and also removes the hcl2 spec generation. The reason for that is, whenever the latest packer is incompatible with the current plugin's packersdk, it would silently override the sdk and the output binaries would be affected by that.
Now, whenever there's an incompatibility between the sdk versions, the release action will fail. 