### PR TITLE
Move version to its own package

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ builds:
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
-      - '-s -w -X main.Version={{.Version}} -X main.VersionPrerelease= '
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     goos:
       - linux
     goarch:
@@ -36,7 +36,7 @@ builds:
     flags:
       - -trimpath #removes all file system paths from the compiled executable
     ldflags:
-      - '-s -w -X main.version={{.Version}} -X main.VersionPrerelease= '
+      - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     goos:
       - freebsd
       - windows

--- a/main.go
+++ b/main.go
@@ -7,23 +7,9 @@ import (
 	scaffoldingData "packer-plugin-scaffolding/datasource/scaffolding"
 	scaffoldingPP "packer-plugin-scaffolding/post-processor/scaffolding"
 	scaffoldingProv "packer-plugin-scaffolding/provisioner/scaffolding"
+	scaffoldingVersion "packer-plugin-scaffolding/version"
 
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
-	"github.com/hashicorp/packer-plugin-sdk/version"
-)
-
-var (
-	// Version is the main version number that is being run at the moment.
-	Version = "0.0.1"
-
-	// VersionPrerelease is A pre-release marker for the Version. If this is ""
-	// (empty string) then it means that it is a final release. Otherwise, this
-	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
-
-	// PluginVersion is used by the plugin set to allow Packer to recognize
-	// what version this plugin is.
-	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
 )
 
 func main() {
@@ -32,7 +18,7 @@ func main() {
 	pps.RegisterProvisioner("my-provisioner", new(scaffoldingProv.Provisioner))
 	pps.RegisterPostProcessor("my-post-processor", new(scaffoldingPP.PostProcessor))
 	pps.RegisterDatasource("my-datasource", new(scaffoldingData.Datasource))
-	pps.SetVersion(PluginVersion)
+	pps.SetVersion(scaffoldingVersion.PluginVersion)
 	err := pps.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,19 @@
+package version
+
+import (
+	"github.com/hashicorp/packer-plugin-sdk/version"
+)
+
+var (
+	// Version is the main version number that is being run at the moment.
+	Version = "0.0.1"
+
+	// VersionPrerelease is A pre-release marker for the Version. If this is ""
+	// (empty string) then it means that it is a final release. Otherwise, this
+	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
+	VersionPrerelease = "dev"
+
+	// PluginVersion is used by the plugin set to allow Packer to recognize
+	// what version this plugin is.
+	PluginVersion = version.InitializePluginVersion(Version, VersionPrerelease)
+)


### PR DESCRIPTION
With reference to [`terraform-provider-aws`](https://github.com/hashicorp/terraform-provider-aws/commit/7a0bb65e526f2a91aca6afb5082dd5208e7f6fee), this change provides builders, provisioners, post-processors and datasources with access to the `PluginVersion` by allowing the import of a `version` package. 

[`terraform-provider-scaffolding`](https://github.com/hashicorp/terraform-provider-scaffolding/blob/main/main.go#L37) exposes the provider version by passing it to the `New` function. In other situations, that would be a better option. However, Packer plugins have too many components to make that option a clean one, therefore we resort to using global variables.

Note that `Version` and `VersionPrerelease` are exposed together with `PluginVersion`. 

Closes #46 