### PR TITLE
Migrate `set-output` to `GITHUB_OUTPUT` environment file

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           go-version: 1.17
       - name: Describe plugin
         id: plugin_describe
-        run: echo "::set-output name=api_version::$(go run . describe | jq -r '.api_version')"
+        run: echo "api_version=$(go run . describe | jq -r '.api_version')" >> $GITHUB_OUTPUT
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5


### PR DESCRIPTION
The `set-output` command is deprecated on 2022-10-11.
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

This PR migrates this command to environment files recommended in the above blog post.