### PR TITLE
Add illumos to default platform list.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -34,6 +34,7 @@ builds:
       - '-s -w -X {{ .ModulePath }}/version.Version={{.Version}} -X {{ .ModulePath }}/version.VersionPrerelease= '
     goos:
       - netbsd
+      - illumos
       - solaris
       - openbsd
       - freebsd


### PR DESCRIPTION
This will hopefully avoid having to submit PRs to individual packer-plugin-* repositories in the future as they are currently missing illumos binaries.

Many thanks.