### PR TITLE
Update allowed dependencies for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    allow:
+      - dependency-name: "github.com/hashicorp/packer-plugin-sdk"


### PR DESCRIPTION
Packer plugins rely on the Packer SDK for the majority of its HCL
dependency. To prevent issues with the version of go-cty or hcl/v2 pkg
getting out of sync this changes sets the allowed dependency to
packer-plugin-sdk only.
