### PR TITLE
Remove VersionPrerelease by default

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -14,7 +14,7 @@ var (
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this
 	// is a pre-release such as "dev" (in development), "beta", "rc1", etc.
-	VersionPrerelease = "dev"
+	VersionPrerelease = ""
 
 	// PluginVersion is used by the plugin set to allow Packer to recognize
 	// what version this plugin is.


### PR DESCRIPTION
See also https://github.com/wata727/packer-plugin-amazon-ami-management/issues/408 https://github.com/wata727/packer-plugin-amazon-ami-management/pull/415

Packer v1.11 no longer supports installing pre-release versions. I was running into issues with my plugins not installing because of this, and had to do a deep dive to understand why they were being marked as pre-release even though they were tagged correctly. As a result, I noticed that the `VersionPrerelease` included in the scaffolding was left as is.

It's probably better for scaffolding to just work as expected "out of the box" as much as possible, so this PR proposes removing the `VersionPrerelease` by default.